### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A distributable Model Context Protocol (MCP) server that exposes Dart SDK commands for AI-powered development. This server bridges the gap between AI coding assistants and Dart/Flutter development workflows by implementing the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/vuwii9l5gu">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/vuwii9l5gu/badge" alt="Dart Server MCP server" />
+</a>
+
 ## Features
 
 This MCP server provides seamless access to the following Dart SDK commands:


### PR DESCRIPTION
This PR adds a badge for the [Dart MCP Server](https://glama.ai/mcp/servers/vuwii9l5gu) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/vuwii9l5gu">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/vuwii9l5gu/badge" alt="Dart Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.